### PR TITLE
workaround url.hostname bug for IPv6 literals - fixes #3

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 
 const parseUrl = require('url').parse
 const parseForwarded = require('forwarded-parse')
+const net = require('net')
 
 module.exports = function (req) {
   const raw = req.originalUrl || req.url
@@ -50,6 +51,9 @@ module.exports = function (req) {
   // hostname
   if (url.hostname) result.hostname = url.hostname
   else if (host.hostname) result.hostname = host.hostname
+
+  // fix for IPv6 literal bug in legacy url - see https://github.com/watson/original-url/issues/3
+  if (net.isIPv6(result.hostname)) result.hostname = '[' + result.hostname + ']'
 
   // port
   if (url.port) result.port = Number(url.port)

--- a/test.js
+++ b/test.js
@@ -51,6 +51,38 @@ test('http - path+query params, no special http headers', function (t) {
   })
 })
 
+test('http - IPv4 host header', function (t) {
+  t.plan(1)
+  const opts = {headers: {
+    'Host': '127.0.0.1'
+  }}
+  http(opts, function (result, port) {
+    t.deepEqual(result, {
+      protocol: 'http:',
+      hostname: '127.0.0.1',
+      pathname: '/',
+      full: 'http://127.0.0.1/',
+      raw: '/'
+    })
+  })
+})
+
+test('http - IPv6 host header', function (t) {
+  t.plan(1)
+  const opts = {headers: {
+    'Host': '[::1]'
+  }}
+  http(opts, function (result, port) {
+    t.deepEqual(result, {
+      protocol: 'http:',
+      hostname: '[::1]',
+      pathname: '/',
+      full: 'http://[::1]/',
+      raw: '/'
+    })
+  })
+})
+
 /**
  * Basic HTTPS
  */


### PR DESCRIPTION
Here's a possible workaround for #3. A proper fix would be to rewrite using the standard `URL` module, but it looks to be a major undertaking given how different those APIs are (You can't create any invalid URL objects, like you could in the legacy variant).