### PR TITLE
Handle no arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,12 +4,16 @@ const parseUrl = require('url').parse
 const parseForwarded = require('forwarded-parse')
 const net = require('net')
 
-module.exports = function (req) {
+module.exports = function (req = {}) {
   const raw = req.originalUrl || req.url
   const url = parseUrl(raw || '')
   const secure = req.secure || (req.connection && req.connection.encrypted)
   const result = { raw: raw }
   let host
+
+  if (!req.headers) {
+    return undefined
+  }
 
   if (req.headers.forwarded) {
     let forwarded = getFirstHeader(req, 'forwarded')

--- a/index.js
+++ b/index.js
@@ -4,7 +4,8 @@ const parseUrl = require('url').parse
 const parseForwarded = require('forwarded-parse')
 const net = require('net')
 
-module.exports = function (req = {}) {
+module.exports = function (req) {
+  req = req || {}
   const raw = req.originalUrl || req.url
   const url = parseUrl(raw || '')
   const secure = req.secure || (req.connection && req.connection.encrypted)

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "tape": "^4.9.1"
   },
   "scripts": {
-    "test": "standard && node test.js"
+    "test": "standard && node test.js",
+    "format": "standard --fix"
   },
   "repository": {
     "type": "git",

--- a/test.js
+++ b/test.js
@@ -691,6 +691,11 @@ test('No Host header', function (t) {
   t.end()
 })
 
+test('Empty arguments', function (t) {
+  t.deepEqual(originalUrl(), undefined)
+  t.end()
+})
+
 /**
  * Utils
  */


### PR DESCRIPTION
Not 100% sure what the correct outcome here should be so take this as a start for a discussion on the behaviour.

Currently the module throws a `TypeError: Cannot read property 'forwarded' of undefined` if a object without a `.headers` property (or no object) is passed on to the `req` argument. Is this intended behaviour?

If yes; could we make the thrown error(s) a bit more explicit?
If no; could we make the module return `undefined` (this PR does so) or an `result` object where `result.full` is not present?