### PR TITLE
Zero out protocol parameter instead of deleting to improve performance

### DIFF
--- a/benchmark/benchmark.js
+++ b/benchmark/benchmark.js
@@ -1,0 +1,50 @@
+'use strict'
+
+const originalUrl = require('../')
+const http = require('http')
+
+function run (onRequest, opts) {
+  const server = http.createServer(function (req, res) {
+    onRequest(req)
+    res.end()
+  })
+
+  server.listen(function () {
+    opts.port = server.address().port
+    const req = http.request(opts, function (res) {
+      res.resume()
+      res.on('end', function () {
+        server.close()
+      })
+    })
+    req.end()
+  })
+}
+
+const COUNT = 1000000
+
+function benchmark (name) {
+  return function (req) {
+    for (let r = 0; r < 4; r++) {
+      const label = 'Run ' + r + ': Benchmark with ' + name + ' took'
+      console.time(label)
+      for (let i = 0; i < COUNT; i++) {
+        originalUrl(req)
+      }
+      console.timeEnd(label)
+    }
+  }
+}
+
+// no special http headers
+run(benchmark('no headers'), {})
+
+// Forwarded - single header
+run(benchmark('Forwarded header'), {headers: {
+  'Forwarded': 'host=example.com; proto=https'
+}})
+
+// X-Forwarded-Host - multiple headers
+run(benchmark('multiple X-Forwarded-Host headers'), {headers: {
+  'X-Forwarded-Host': ['example.com', 'example.net']
+}})

--- a/index.js
+++ b/index.js
@@ -92,7 +92,7 @@ function getFirstHeader (req, header) {
 
 function parsePartialURL (url) {
   const containsProtocol = url.indexOf('://') !== -1
-  url = parseUrl(containsProtocol ? url : 'invalid://' + url)
-  if (!containsProtocol) delete url.protocol
-  return url
+  const result = parseUrl(containsProtocol ? url : 'invalid://' + url)
+  if (!containsProtocol) result.protocol = ''
+  return result
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
     "tape": "^4.9.1"
   },
   "scripts": {
+    "format": "standard --fix",
+    "bench": "node benchmark/benchmark.js",
     "test": "standard && node test.js"
   },
   "repository": {


### PR DESCRIPTION
This improves the performance by a 1000ms on a million runs.

Previously:

```sh
Run 0: Benchmark with no headers took: 2757.767ms
Run 1: Benchmark with no headers took: 2732.211ms
Run 2: Benchmark with no headers took: 2795.459ms
Run 3: Benchmark with no headers took: 2738.267ms
Run 0: Benchmark with Forwarded header took: 3436.794ms
Run 1: Benchmark with Forwarded header took: 3442.375ms
Run 2: Benchmark with Forwarded header took: 3413.114ms
Run 3: Benchmark with Forwarded header took: 3405.076ms
Run 0: Benchmark with multiple X-Forwarded-Host headers took: 2719.612ms
Run 1: Benchmark with multiple X-Forwarded-Host headers took: 2691.415ms
Run 2: Benchmark with multiple X-Forwarded-Host headers took: 2684.705ms
Run 3: Benchmark with multiple X-Forwarded-Host headers took: 2694.015ms
```

After:

```sh
Run 0: Benchmark with no headers took: 1759.048ms
Run 1: Benchmark with no headers took: 1741.105ms
Run 2: Benchmark with no headers took: 1733.430ms
Run 3: Benchmark with no headers took: 1766.368ms
Run 0: Benchmark with Forwarded header took: 2433.636ms
Run 1: Benchmark with Forwarded header took: 2409.549ms
Run 2: Benchmark with Forwarded header took: 2400.254ms
Run 3: Benchmark with Forwarded header took: 2413.262ms
Run 0: Benchmark with multiple X-Forwarded-Host headers took: 1785.926ms
Run 1: Benchmark with multiple X-Forwarded-Host headers took: 1786.500ms
Run 2: Benchmark with multiple X-Forwarded-Host headers took: 1783.425ms
Run 3: Benchmark with multiple X-Forwarded-Host headers took: 1787.137ms
```