### PR TITLE
Use request.socket over deprecated request.connection

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const net = require('net')
 module.exports = function (req) {
   const raw = req.originalUrl || req.url
   const url = parseUrl(raw || '')
-  const secure = req.secure || (req.connection && req.connection.encrypted)
+  const secure = req.secure || (req.socket && req.socket.encrypted)
   const result = { raw: raw }
   let host
 


### PR DESCRIPTION
This replaces the use of `request.connection` with `request.socket`. `request.connection` was [deprecated in node 13](https://nodejs.org/dist/latest-v16.x/docs/api/http.html#requestconnection) and is causing an deprecation warning when this module [is used together with Fastify](https://github.com/podium-lib/issues/issues/52).

