### PR TITLE
Deprecate url.parse API in favor of URL constructor

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,6 @@ module.exports = function (req) {
       // passed through multiple proxies
       forwarded = parseForwarded(forwarded)[0]
       host = parsePartialURL(forwarded.host)
-      console.log('forwarded host', host)
       if (forwarded.for) {
         const conn = forwarded.for.split(']') // in case of IPv6 addr: [2001:db8:cafe::17]:1337
         const port = conn[conn.length - 1].split(':')[1]

--- a/index.js
+++ b/index.js
@@ -94,10 +94,9 @@ function getFirstHeader (req, header) {
 function parsePartialURL (url) {
   const containsProtocol = url.indexOf('://') !== -1
   const urlInstance = new URL(containsProtocol ? url : 'invalid://' + url)
-  const props = ['hash', 'host', 'hostname', 'href', 'pathname', 'protocol', 'port', 'pathname', 'search']
   const result = {}
-  for (const p of props) {
-    result[p] = urlInstance[p]
+  for (const prop in urlInstance) {
+    if (typeof urlInstance[prop] !== 'function') result[prop] = urlInstance[prop]
   }
   if (!containsProtocol) {
     result.protocol = ''

--- a/test.js
+++ b/test.js
@@ -22,6 +22,34 @@ test('http - root, no special http headers', function (t) {
   })
 })
 
+test('http - double slash, no special http headers', function (t) {
+  t.plan(1)
+  http({path: '//some/path'}, function (result, port) {
+    t.deepEqual(result, {
+      protocol: 'http:',
+      hostname: 'localhost',
+      port: port,
+      pathname: '//some/path',
+      full: 'http://localhost:' + port + '//some/path',
+      raw: '//some/path'
+    })
+  })
+})
+
+test('http - auth like, no special http headers', function (t) {
+  t.plan(1)
+  http({path: '//user@pass'}, function (result, port) {
+    t.deepEqual(result, {
+      protocol: 'http:',
+      hostname: 'localhost',
+      port: port,
+      pathname: '//user@pass',
+      full: 'http://localhost:' + port + '//user@pass',
+      raw: '//user@pass'
+    })
+  })
+})
+
 test('http - path, no special http headers', function (t) {
   t.plan(1)
   http({path: '/some/path'}, function (result, port) {
@@ -111,6 +139,34 @@ test('https - path, no special http headers', function (t) {
       pathname: '/some/path',
       full: 'https://localhost:' + port + '/some/path',
       raw: '/some/path'
+    })
+  })
+})
+
+test('http - double slash, no special http headers', function (t) {
+  t.plan(1)
+  https({path: '//some/path'}, function (result, port) {
+    t.deepEqual(result, {
+      protocol: 'https:',
+      hostname: 'localhost',
+      port: port,
+      pathname: '//some/path',
+      full: 'https://localhost:' + port + '//some/path',
+      raw: '//some/path'
+    })
+  })
+})
+
+test('http - auth like, no special http headers', function (t) {
+  t.plan(1)
+  https({path: '//user@pass'}, function (result, port) {
+    t.deepEqual(result, {
+      protocol: 'https:',
+      hostname: 'localhost',
+      port: port,
+      pathname: '//user@pass',
+      full: 'https://localhost:' + port + '//user@pass',
+      raw: '//user@pass'
     })
   })
 })

--- a/test.js
+++ b/test.js
@@ -747,6 +747,15 @@ test('No Host header', function (t) {
   t.end()
 })
 
+test('Weird auth string', function (t) {
+  const mockReq = {url: '@@', headers: {}, connection: {}}
+  t.deepEqual(originalUrl(mockReq), {
+    protocol: 'http:',
+    raw: '@@'
+  })
+  t.end()
+})
+
 /**
  * Utils
  */


### PR DESCRIPTION
Replace the legacy `parse` API from `url` module and use the `URL` constructor instead. Reasons for this change are:

- API is deprecated and it use discouraged in [the documentation](https://nodejs.org/dist/latest-v18.x/docs/api/url.html#urlparseurlstring-parsequerystring-slashesdenotehost)
- Consumers of the package have discovered issues related to the parsing algorithm ([example](https://github.com/elastic/apm-agent-nodejs/issues/3137))
    - URLs starting with double slash `//some/path` are not parsed correctly
    - URLs with auth like form `//user@foo` have the same problem

The solution proposed in this PR considers the raw URL as partial like the ones seek on the headers and adding a fake protocol if necessary (to remove later). The function iterates over the URL instance properties to fill a result object since some properties of URL do not accept empty values like protocol.

```javascript
const url = new URL('https://localhost:8080/path')
console.log(url.protocol) // prints "https:"
url.protocol = '';
console.log(url.protocol) // keeps printing "https:"
```

Tests have been added in  http/https requests to test these specific scenarios.