### PR TITLE
Fix for req.secure failure

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const net = require('net')
 module.exports = function (req) {
   const raw = req.originalUrl || req.url
   const url = parseUrl(raw || '')
-  const secure = req.secure || (req.connection && req.connection.encrypted)
+  const secure = safeGetReqSecure(req) || (req.connection && req.connection.encrypted)
   const result = { raw: raw }
   let host
 
@@ -95,4 +95,12 @@ function parsePartialURL (url) {
   const result = parseUrl(containsProtocol ? url : 'invalid://' + url)
   if (!containsProtocol) result.protocol = ''
   return result
+}
+
+function safeGetReqSecure(req) {
+  try {
+    return req.secure
+  } catch(err) {
+    return false
+  }
 }


### PR DESCRIPTION
In some cases, req.secure fails with `TypeError: trust is not a function`. This fix catches the failure without crashing the app.

Failure when accessing `req.secure`

```
 TypeError: trust is not a function
    at IncomingMessage.protocol (/Users/devmachine/porposal/sales-api/node_modules/express/lib/request.js:312:8)
    at IncomingMessage.secure (/Users/devmachine/porposal/sales-api/node_modules/express/lib/request.js:336:15)
    at module.exports (/Users/devmachine/porposal/sales-api/node_modules/original-url/index.js:10:22)
    at Object.exports.getRequestParams (/Users/devmachine/porposal/sales-api/lib/request-params.js:97:10)
 ```